### PR TITLE
Convert metadata into YAML frontmatter

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,7 +1,9 @@
-- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
-- RFC PR: [crystal-lang/rfcs#0000](https://github.com/crystal-lang/rfcs/pull/0000) (fill me in after creating the PR, also update the filename)
-- Issue: [crystal-lang/crystal#0000](https://github.com/crystal-lang/crystal/issues/0000)
+---
+Feature Name: # fill me in with a unique ident, `my_awesome_feature`
+Start Date: # fill me in with today's date, YYYY-MM-DD
+RFC PR: "[crystal-lang/rfcs#0000](https://github.com/crystal-lang/rfcs/pull/0000)" # fill me in after creating the PR, also update the filename
+Issue: "[crystal-lang/crystal#0000](https://github.com/crystal-lang/crystal/issues/0000)"
+---
 
 # Summary
 

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,8 +1,8 @@
 ---
 Feature Name: # fill me in with a unique ident, `my_awesome_feature`
 Start Date: # fill me in with today's date, YYYY-MM-DD
-RFC PR: "[crystal-lang/rfcs#0000](https://github.com/crystal-lang/rfcs/pull/0000)" # fill me in after creating the PR, also update the filename
-Issue: "[crystal-lang/crystal#0000](https://github.com/crystal-lang/crystal/issues/0000)"
+RFC PR: "https://github.com/crystal-lang/rfcs/pull/0000" # fill me in after creating the PR, also update the filename
+Issue: "https://github.com/crystal-lang/crystal/issues/0000"
 ---
 
 # Summary

--- a/text/0001-RFCs proposal.md
+++ b/text/0001-RFCs proposal.md
@@ -1,7 +1,7 @@
 ---
 Feature Name: rfcs_proposal
 Start Date: 2024-01-30
-RFC PR: "[crystal-lang/rfcs#0001](https://github.com/crystal-lang/rfcs/pull/0001)"
+RFC PR: "https://github.com/crystal-lang/rfcs/pull/0001"
 Issue: null
 ---
 

--- a/text/0001-RFCs proposal.md
+++ b/text/0001-RFCs proposal.md
@@ -1,7 +1,9 @@
-- Feature Name: rfcs_proposal
-- Start Date: 2024-01-30
-- RFC PR: [crystal-lang/rfcs#0001](https://github.com/crystal-lang/rfcs/pull/0001)
-- Issue: N/A
+---
+Feature Name: rfcs_proposal
+Start Date: 2024-01-30
+RFC PR: "[crystal-lang/rfcs#0001](https://github.com/crystal-lang/rfcs/pull/0001)"
+Issue: null
+---
 
 # Summary
 

--- a/text/0003-wait-group.md
+++ b/text/0003-wait-group.md
@@ -1,8 +1,8 @@
 ---
 Feature Name: wait_group
 Start Date: 2024-02-06
-RFC PR: "[crystal-lang/rfcs#3](https://github.com/crystal-lang/rfcs/pull/3)"
-Implementation PR: "[crystal-lang/crystal#14167](https://github.com/crystal-lang/crystal/pull/14167)"
+RFC PR: "https://github.com/crystal-lang/rfcs/pull/3"
+Implementation PR: "https://github.com/crystal-lang/crystal/pull/14167"
 ---
 
 # Summary

--- a/text/0003-wait-group.md
+++ b/text/0003-wait-group.md
@@ -1,7 +1,9 @@
-- Feature Name: `wait_group`
-- Start Date: 2024-02-06
-- RFC PR: [crystal-lang/rfcs#3](https://github.com/crystal-lang/rfcs/pull/3)
-- Implementation PR: [crystal-lang/crystal#14167](https://github.com/crystal-lang/crystal/pull/14167)
+---
+Feature Name: wait_group
+Start Date: 2024-02-06
+RFC PR: "[crystal-lang/rfcs#3](https://github.com/crystal-lang/rfcs/pull/3)"
+Implementation PR: "[crystal-lang/crystal#14167](https://github.com/crystal-lang/crystal/pull/14167)"
+---
 
 # Summary
 

--- a/text/0007-event_loop-refactor.md
+++ b/text/0007-event_loop-refactor.md
@@ -1,7 +1,9 @@
-- Feature Name: `event_loop-refactor`
-- Start Date: 2023-05-02
-- RFC PR: [crystal-lang/rfcs#0007](https://github.com/crystal-lang/rfcs/pull/0007)
-- Issue: [crystal-lang/crystal#10766](https://github.com/crystal-lang/crystal/issues/10766)
+---
+Feature Name: event_loop-refactor
+Start Date: 2023-05-02
+RFC PR: "[crystal-lang/rfcs#0007](https://github.com/crystal-lang/rfcs/pull/0007)"
+Issue: "[crystal-lang/crystal#10766](https://github.com/crystal-lang/crystal/issues/10766)"
+---
 
 # Summary
 

--- a/text/0007-event_loop-refactor.md
+++ b/text/0007-event_loop-refactor.md
@@ -1,8 +1,8 @@
 ---
 Feature Name: event_loop-refactor
 Start Date: 2023-05-02
-RFC PR: "[crystal-lang/rfcs#0007](https://github.com/crystal-lang/rfcs/pull/0007)"
-Issue: "[crystal-lang/crystal#10766](https://github.com/crystal-lang/crystal/issues/10766)"
+RFC PR: "https://github.com/crystal-lang/rfcs/pull/0007"
+Issue: "https://github.com/crystal-lang/crystal/issues/10766"
 ---
 
 # Summary

--- a/text/0009-lifetime-event_loop.md
+++ b/text/0009-lifetime-event_loop.md
@@ -1,9 +1,9 @@
-- Feature Name: `lifetime-event_loop`
-- Start Date: 2024-11-11
-- RFC PR:
-  [crystal-lang/rfcs#0009](https://github.com/crystal-lang/rfcs/pull/9)
-- Issue:
-  [crystal-lang/crystal#14996](https://github.com/crystal-lang/crystal/pull/14996)
+---
+Feature Name: lifetime-event_loop
+Start Date: 2024-11-11
+RFC PR: "[crystal-lang/rfcs#0009](https://github.com/crystal-lang/rfcs/pull/9)"
+Issue: "[crystal-lang/crystal#14996](https://github.com/crystal-lang/crystal/pull/14996)"
+---
 
 # Summary
 

--- a/text/0009-lifetime-event_loop.md
+++ b/text/0009-lifetime-event_loop.md
@@ -1,8 +1,8 @@
 ---
 Feature Name: lifetime-event_loop
 Start Date: 2024-11-11
-RFC PR: "[crystal-lang/rfcs#0009](https://github.com/crystal-lang/rfcs/pull/9)"
-Issue: "[crystal-lang/crystal#14996](https://github.com/crystal-lang/crystal/pull/14996)"
+RFC PR: "https://github.com/crystal-lang/rfcs/pull/9"
+Issue: "https://github.com/crystal-lang/crystal/pull/14996"
 ---
 
 # Summary


### PR DESCRIPTION
Instead of a unspecific markdown list we can use YAML frontmatter to declare metadata for the RFC document. This is a more formalized data format and makes it easier to extract information from the document. It also renders quite nicely in GitHub.
In the process I'm also simplifying the PR and issue references to keep them cleen URLs (they're rendered as short reference on GitHub).

After merging this we need to patch pending PRs as well to ensure a consistent format.